### PR TITLE
Add martin-majlis as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BastianZim
+* @BastianZim @martin-majlis

--- a/README.md
+++ b/README.md
@@ -149,4 +149,5 @@ Feedstock Maintainers
 =====================
 
 * [@BastianZim](https://github.com/BastianZim/)
+* [@martin-majlis](https://github.com/martin-majlis/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,3 +46,4 @@ about:
 extra:
   recipe-maintainers:
     - BastianZim
+    - martin-majlis

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 948e983fe52f26bec7b63105b73e8067e89e14fcf03464f5c051be4273afb8e6
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
I am maintainer of https://github.com/martin-majlis/Wikipedia-API, so I would like to help with keeping pypi and conda version in sync.

It looks that there was a large lag in the past - https://github.com/martin-majlis/Wikipedia-API/issues/253

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

